### PR TITLE
Change capitalisation in the name: transgrp -> TransGrp

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -1,9 +1,9 @@
-# PackageInfo for transgrp
+# PackageInfo for the TransGrp package
 
 SetPackageInfo( rec(
 
 ##  This is case sensitive, use your preferred spelling.
-PackageName := "transgrp",
+PackageName := "TransGrp",
 Subtitle := "Transitive Groups Library",
 
 ##  See '?Extending: Version Numbers' in GAP help for an explanation
@@ -82,7 +82,7 @@ PackageInfoURL := "http://www.math.colostate.edu/~hulpke/transgrp/PackageInfo.g"
 ##  Please, use '<span class="pkgname">GAP</span>' and
 ##  '<span class="pkgname">MyPKG</span>' for specifing package names.
 ##  
-AbstractHTML := "The <span class=\"transgrp\">transgrp</span> package provides \
+AbstractHTML := "The <span class=\"transgrp\">TransGrp</span> package provides \
 the library of transitive groups.",
 
 PackageWWWHome := "http://www.math.colostate.edu/~hulpke/transgrp",

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -1,6 +1,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%W  manual.tex              transgrp documentation       
+%W  manual.tex              TransGrp documentation       
 %%
 %H  $Id: manual.tex,v 1.3 2001/10/11 14:24:15 gap Exp $
 %%
@@ -32,7 +32,7 @@
 %F  TitlePage . . . . . . . . . . . . . . . . . . . . . . nice title page
 %%
 \TitlePage{
-  \centerline{\titlefont transgrp}\bigskip\bigskip\bigskip
+  \centerline{\titlefont TransGrp}\bigskip\bigskip\bigskip
   \centerline{\secfont Library of Transitive Groups}\vfill
   \centerline{\secfont by}\bigskip\bigskip\bigskip
   \centerline{\secfont Alexander Hulpke}\bigskip

--- a/init.g
+++ b/init.g
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-##  init.g                transgrp package                  Alexander Hulpke
+##  init.g                TransGrp package                  Alexander Hulpke
 ##
 ##  Copyright 2016 by the author.
 ##

--- a/read.g
+++ b/read.g
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-##  read.g                transgrp package                  Alexander Hulpke
+##  read.g                TransGrp package                  Alexander Hulpke
 ##
 ##  Copyright 2016 by the author.
 ##


### PR DESCRIPTION
This is a suggestion to address #19 and change capitalisation in the name: transgrp -> TransGrp. It does not require any other actions, since no files and repositories are renamed, and will be seamlessly picked up when there will be a time for the next release.