### PR TITLE
Specify URLs of the repository and its issue tracker

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -89,6 +89,11 @@ PackageInfoURL := "https://www.math.colostate.edu/~hulpke/transgrp/PackageInfo.g
 AbstractHTML := "The <span class=\"transgrp\">TransGrp</span> package provides \
 the library of transitive groups.",
 
+SourceRepository := rec(
+    Type := "git",
+    URL := Concatenation( "https://github.com/hulpke/", LowercaseString( ~.PackageName ) ),
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
 PackageWWWHome := "https://www.math.colostate.edu/~hulpke/transgrp",
                   
 ##  On the GAP Website there is an online version of all manuals in the


### PR DESCRIPTION
In particular, this information will be then displayed on the GAP website from the package overview page, like e.g. at https://www.gap-system.org/Packages/example.html