### PR TITLE
Add missing directory for the HTML-version of the documentation

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -112,7 +112,7 @@ PackageWWWHome := "https://www.math.colostate.edu/~hulpke/transgrp",
 PackageDoc := rec(
   # use same as in GAP            
   BookName := "transgrp",
-  ArchiveURLSubset := [ "doc/manual.pdf"],
+  ArchiveURLSubset := [ "doc/manual.pdf","htm" ],
   PDFFile := "doc/manual.pdf",
   HTMLStart:="htm/chapters.htm",
   # the path to the .six file used by GAP's help system


### PR DESCRIPTION
@fingolfin noticed that the link to the HTML-version of the PrimGrp manual at https://www.gap-system.org/Packages/transgrp.html is broken. I've investigated this and the problem was that the `htm` directory was missing in the `PackageInfo.g` file as a part of the documentation.

Indeed, as https://github.com/gap-packages/example/blob/master/PackageInfo.g says, you need to
```
##      - give the paths to the files inside your package directory
##        which are needed for the online manual (as a list 
##        .ArchiveURLSubset of names of directories and/or files which 
##        should be copied from your package archive, given in .ArchiveURL 
##        above (in most cases, ["doc"] or ["doc","htm"] suffices).
```

This PR fixes that.