### PR TITLE
Fix `TestDirectory` arguments

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -7,6 +7,6 @@
 LoadPackage( "transgrp" );
 
 TestDirectory(DirectoriesPackageLibrary( "transgrp", "tst" ),
-  rec(exitGAP := true,ignoreComments:=true,compareFunction:="uptowhitespace"));
+  rec(exitGAP := true,testOptions := rec(compareFunction:="uptowhitespace")));
 
 FORCE_QUIT_GAP(1); # if we ever get here, there was an error


### PR DESCRIPTION
... to ensure it really ignores whitespace. Note that `ignoreComments`
defaults to `true`, so no need to specify that.
