### PR TITLE
Load GAPDoc and SmallGrp before testing

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -4,6 +4,8 @@
 # This file runs package tests. It is also referenced in the package
 # metadata in PackageInfo.g.
 #
+LoadPackage( "gapdoc" );
+LoadPackage( "smallgrp" );
 LoadPackage( "transgrp" );
 
 TestDirectory(DirectoriesPackageLibrary( "transgrp", "tst" ),


### PR DESCRIPTION
This is helpful when installing GAP and its packages one-at-a-time, running the test suites along the way (i.e. how the Gentoo package manager installs things). Before all of smallgrp, primgrp, transgrp, and gapdoc are installed, passing `--bare` to gap is needed to avoid startup errors. But in that case, transgrp needs to load them explicitly for its test suite to pass.
